### PR TITLE
グループ作成または編集時においてのユーザー名インクリメンタルサーチ実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,5 +1,65 @@
 $(function() {
+
+  let search_user_list = $("#UserSearchResult");
+
+  function appendUser(user) {
+    let html = `<div class="ChatMember clearfix">
+                  <p class="ChatMember__name">${user.name}</p>
+                  <div class="ChatMember__add ChatMember__button" data-user-id=${user.id} data-user-name=${user.name}>追加</div>
+                </div>`
+    search_user_list.append(html);
+  }
+
+  function appendErrMsgToHTML(msg) {
+    let html = `<div class="ChatMember clearfix">
+                  <p class="ChatMember__name">${msg}</p>
+                </div>`
+    search_user_list.append(html);
+  }
+
+  function appendChatMember(name, id) {
+    let html = `<div class="ChatMember">
+                  <p class="ChatMember__name">${name}</p>
+                  <input name="group[user_ids][]" type="hidden" value=${id} />
+                  <div class="ChatMember__remove ChatMember__button">削除</div>
+                </div>`
+    $(".ChatMembers").append(html);
+  }
+
   $("#UserSearch__field").on("keyup", function() {
     let input = $("#UserSearch__field").val();
-  })
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      search_user_list.empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          appendUser(user);
+        })
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        appendErrMsgToHTML("ユーザーが見つかりません");
+      }
+    })
+    .fail(function() {
+      alert("ユーザー検索に失敗しました");
+    });
+  });
+
+  search_user_list.on("click", ".ChatMember__add", function() {
+    let id = $(this).attr("data-user-id");
+    let name = $(this).attr("data-user-name");
+    let add = $(this).parent();
+    add.remove();
+    appendChatMember(name, id);
+  });
+  $(".ChatMembers").on("click", ".ChatMember__remove", function() {
+    let del = $(this).parent();
+    del.remove();
+  });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,5 @@
+$(function() {
+  $("#UserSearch__field").on("keyup", function() {
+    let input = $("#UserSearch__field").val();
+  })
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def index
+    @users = User.search(params[:keyword])
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   private
   def user_params
     params.require(:user).permit(:email,:name)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.search(params[:keyword])
+    @users = User.search(params[:keyword], current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
   has_many :group_users
   has_many :groups, through: :group_users
   validates :name, presence: true, uniqueness: true
+
+  def self.search(search)
+    User.where('name LIKE(?)', "%#{search}%")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,8 @@ class User < ApplicationRecord
   has_many :groups, through: :group_users
   validates :name, presence: true, uniqueness: true
 
-  def self.search(search)
-    User.where('name LIKE(?)', "%#{search}%")
+  def self.search(name, id)
+    return nil if name == ""
+    User.where('name LIKE(?)', "%#{name}%").where.not(id: id).limit(10)
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -15,8 +15,16 @@
       %label.SettingGroupForm__label チャットメンバーを追加
     .SettingGroupForm__rightField
       -# グループ作成機能の追加時はここにcollection_check_boxesの記述を入れる
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      -# = f.collection_check_boxes :user_ids, User.all, :id, :name
       -# この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用する
+      .UserSearch
+        %input#UserSearch__field.SettingGroupForm__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
+      #UserSearchResult
+  .SettingGroupForm__field
+    .SettingGroupForm__leftField
+      = f.label :name, value: "チャットメンバー", class:"SettingGroupForm__label"
+    .SettingGroupForm__rightFied
+      .ChatMembers
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -23,8 +23,17 @@
   .SettingGroupForm__field
     .SettingGroupForm__leftField
       = f.label :name, value: "チャットメンバー", class:"SettingGroupForm__label"
-    .SettingGroupForm__rightFied
+    .SettingGroupForm__rightField
       .ChatMembers
+        .ChatMember
+          %p.ChatMember__name= current_user.name
+          %input{name: "group[user_ids][]", type:"hidden", value: current_user.id}
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .ChatMember
+              %p.ChatMember__name= user.name
+              .ChatMember__remove.ChatMember__button{"data-user-id": user.id, "data-user-name": user.name} 削除
+              %input{name: "group[user_ids][]", type:"hidden", value: user.id}
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update,]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
チャットメンバー追加機能において、チェックボックス形式だった実装をインクリメンタルサーチ実装の為のテキストフィールドに変更。Ajaxを使用し、文字が入力される度に非同期通信を行って、usersコントローラーからuserモデル内のwhereメソッドによりユーザー名を検索できるように実装。jbuilderから送られてきた検索結果の配列データを得て、一つのデータを埋め込むHTMLをテンプレートリテラルで作成し、検索結果によって、テキストフィールドに文字が入力された場合・何も入力されていない場合・入力されているが該当がない場合の3パターンで条件分岐を設定。テキストフィールドに文字が入力された場合は該当データをforEach文にて一つずつ表示するように実装。何も入力されていない場合はあえて何もアラートを出さず、入力されているが該当がない場合に「ユーザーが見つかりません」というメッセージが表示されるように実装。また、検索の通信自体に失敗した場合に「ユーザー検索に失敗しました」というアラートメッセージが画面に表示されるように設定。次に、一つの検索結果のデータに実装されているグループメンバーに追加する為の「追加」ボタンを押すとイベントが発火され、グループメンバーにアサインされると共に、検索結果からは削除されるように実装。また、グループメンバーへ遷移すると「追加」ボタンだった箇所が「削除」ボタンへ変わり、押すとグループのアサインから外れるように設定。これは追加or削除ボタンをクリックした際にinput要素のnameに設定したuser_idsへ情報を追加or削除されるように実装している為である。次に、ログイン中のユーザー名を予め追加済みの状態として表示すると共に、グループの編集画面へ遷移した際にもログイン中のユーザー名と、そのグループの既存ユーザー名が予め表示されているように実装。グループの編集画面へ遷移した際には、ログイン中のユーザー以外はeach文に入れ、if文でログイン中でないユーザーかどうかを確認してから一覧表示している。

# Why
ユーザーがサービスを利用するにあたって、頻繁に使用するグループ作成・編集において、毎度必要となる情報の手動操作を自動化し、スムーズなサービスの利用と、ストレスのない操作を実現する為。